### PR TITLE
docs update: Update Auction doc page to work with latest changes

### DIFF
--- a/documentation/leo/10_auction.md
+++ b/documentation/leo/10_auction.md
@@ -81,8 +81,9 @@ Swap in the private key and address of the first bidder to `.env`.
 
 ```bash
 echo "
-NETWORK=testnet3
+NETWORK=testnet
 PRIVATE_KEY=APrivateKey1zkpG9Af9z5Ha4ejVyMCqVFXRKknSm8L1ELEwcc4htk9YhVK
+ENDPOINT=https://localhost:3030
 " > .env
 ```
 
@@ -100,8 +101,9 @@ Swap in the private key of the second bidder to `.env`.
 
 ```bash
 echo "
-NETWORK=testnet3
+NETWORK=testnet
 PRIVATE_KEY=APrivateKey1zkpAFshdsj2EqQzXh5zHceDapFWVCwR6wMCJFfkLYRKupug
+ENDPOINT=https://localhost:3030
 " > .env
 ```
 
@@ -119,8 +121,9 @@ Swap in the private key of the auctioneer to `.env`.
 
 ```bash
 echo "
-NETWORK=testnet3
+NETWORK=testnet
 PRIVATE_KEY=APrivateKey1zkp5wvamYgK3WCAdpBQxZqQX8XnuN2u11Y6QprZTriVwZVc
+ENDPOINT=https://localhost:3030
 " > .env
 ```
 


### PR DESCRIPTION
The doc page is outdated:

1. `testnet3` does not exist, the correct identifier is `testnet`.
2. The `.env` file requires an `ENDPOINT`.  I have configured it to the localhost with a port of `3030`.